### PR TITLE
Added Audio to the category for MATE 1.24.0

### DIFF
--- a/data/io.github.Pithos.desktop.in
+++ b/data/io.github.Pithos.desktop.in
@@ -2,7 +2,7 @@
 Name=Pithos
 Comment=Play music from Pandora Radio
 Keywords=Music;
-Categories=GNOME;AudioVideo;Player;
+Categories=GNOME;Audio;AudioVideo;Player;
 Exec=pithos
 Icon=io.github.Pithos
 Terminal=false


### PR DESCRIPTION
When I install Pithos from the Ubuntu-MATE repository, there is no menu entry added. I added an additional category that works.